### PR TITLE
Fix build with GHC8 and remove redundant constraint

### DIFF
--- a/src/KRPCHS/Internal/Requests.hs
+++ b/src/KRPCHS/Internal/Requests.hs
@@ -74,7 +74,7 @@ emptyKRPCStreamMsg = KRPCStreamMsg M.empty
 
 
 class (PbSerializable a) => KRPCResponseExtractable a where
-    extract :: (PbSerializable a) => KRes.Response -> Either ProtocolError a
+    extract :: KRes.Response -> Either ProtocolError a
     extract r = do
         checkError r
         maybe (Left ResponseEmpty) (decodePb) (KRes.return_value r)

--- a/src/KRPCHS/Internal/Requests.hs
+++ b/src/KRPCHS/Internal/Requests.hs
@@ -152,7 +152,7 @@ makeStream r = KRPCStreamReq $
     makeRequest "KRPC" "AddStream" [KArg.Argument (Just 0) (Just $ messagePut r)]
 
 
-requestStream :: KRPCResponseExtractable a => KRPCStreamReq a -> RPCContext (KRPCStream a)
+requestStream :: KRPCStreamReq a -> RPCContext (KRPCStream a)
 requestStream KRPCStreamReq{..} = do
     res <- sendRequest streamReq
     sid <- processResponse res


### PR DESCRIPTION
GHC 8.0 give following error:

```
src/KRPCHS/Internal/Requests.hs:77:5: error:
    • Constraint ‘PbSerializable a’ in the type of ‘extract’
        constrains only the class type variables
      Use ConstrainedClassMethods to allow it
    • When checking the class method:
        extract :: forall a.
                   (KRPCResponseExtractable a, PbSerializable a) =>
                   KRes.Response -> Either ProtocolError a
      In the class declaration for ‘KRPCResponseExtractable’
```

so I removed constraint from method. It's not needed anyway since it's provided by superclass constraint. 

Also I removed redundant constraint on method